### PR TITLE
feat: Expand custom menu items to support 0-10 configurable entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Kiwi Menu replaces the Activities button with a compact, macOS-inspired launcher
 - **Recent items submenu**: Hover or click to browse recent files and folders with automatic section headers and quick launch support.
 - **Force Quit overlay**: Launches the built-in xkill helper from the menu when an app misbehaves. Optionaly, can also close all apps in current workspace.
 - **Custom AppStore command**: Add your distro specific App store shortcut
-- **Personalized Menu Item**: Add one custom menu entry of your choice
+- **Custom Menu Items**: Add up to 10 custom menu entries of your choice
 - **Adaptive logout label**: Personalizes the log out entry with your full name when available.
 - **Curated session controls**: Sleep, restart, shut down, lock, and log out entries mirror the macOS Apple menu workflow.
 - **Hide Activities**: Hide activities button in top panel.

--- a/prefs.js
+++ b/prefs.js
@@ -143,194 +143,236 @@ const OptionsPage = GObject.registerClass(
 
       menuGroup.add(appStoreCommandRow);
 
-      // Custom menu item section - using ExpanderRow
-      const customMenuExpanderRow = new Adw.ExpanderRow({
-        title: this._('Custom Menu Item'),
-        subtitle: this._('Add a custom menu entry with your own label and command.'),
-        show_enable_switch: true,
-        enable_expansion: this._settings.get_boolean('custom-menu-enabled'),
+      // Custom menu count selector
+      const customMenuCountList = new Gtk.StringList();
+      for (let i = 0; i <= 10; i++) {
+        customMenuCountList.append(i.toString());
+      }
+
+      const customMenuCountRow = new Adw.ComboRow({
+        title: this._('Custom Menu Items'),
+        subtitle: this._('Number of custom menu items to display (0-10).'),
+        model: customMenuCountList,
+        selected: this._settings.get_int('custom-menu-count'),
       });
 
-      // Custom menu label entry
-      const defaultMenuLabel = '';
-      const customMenuLabelRow = new Adw.EntryRow({
-        title: this._('Menu Label'),
-      });
-      customMenuLabelRow.set_placeholder_text?.('My Custom Entry');
-      customMenuLabelRow.set_text(this._settings.get_string('custom-menu-label'));
+      menuGroup.add(customMenuCountRow);
 
-      const labelRestoreButton = new Gtk.Button({
-        icon_name: 'edit-undo-symbolic',
-        has_frame: false,
-        tooltip_text: this._('Restore Default'),
-        valign: Gtk.Align.CENTER,
-      });
-      labelRestoreButton.add_css_class?.('circular');
+      // Store expander rows for visibility control
+      const customMenuExpanders = [];
 
-      const labelAcceptButton = new Gtk.Button({
-        icon_name: 'emblem-ok-symbolic',
-        has_frame: false,
-        tooltip_text: this._('Apply Changes'),
-        valign: Gtk.Align.CENTER,
-      });
-      labelAcceptButton.add_css_class?.('circular');
-      labelAcceptButton.set_visible(false);
-      labelAcceptButton.set_sensitive(false);
+      // Custom menu items section - 10 items max
+      for (let i = 1; i <= 10; i++) {
+        const enabledKey = `custom-menu-${i}-enabled`;
+        const labelKey = `custom-menu-${i}-label`;
+        const commandKey = `custom-menu-${i}-command`;
 
-      customMenuLabelRow.add_suffix?.(labelAcceptButton);
-      customMenuLabelRow.add_suffix?.(labelRestoreButton);
+        const customMenuExpanderRow = new Adw.ExpanderRow({
+          title: this._('Custom Menu Item %d').format(i),
+          subtitle: this._('Add a custom menu entry with your own label and command.'),
+          show_enable_switch: true,
+          enable_expansion: this._settings.get_boolean(enabledKey),
+        });
 
-      const clearLabelFocus = () => {
-        const root = customMenuLabelRow.get_root?.();
-        if (root && typeof root.set_focus === 'function') {
-          root.set_focus(null);
-        }
-      };
+        // Custom menu label entry
+        const defaultMenuLabel = '';
+        const customMenuLabelRow = new Adw.EntryRow({
+          title: this._('Menu Label'),
+        });
+        customMenuLabelRow.set_placeholder_text?.('My Custom Entry');
+        customMenuLabelRow.set_text(this._settings.get_string(labelKey));
 
-      const updateLabelRestoreButtonState = () => {
-        const currentText = customMenuLabelRow.get_text
-          ? customMenuLabelRow.get_text()
-          : customMenuLabelRow.text ?? '';
-        const isDefault = currentText.trim() === defaultMenuLabel;
-        labelRestoreButton.set_sensitive(!isDefault);
-        labelRestoreButton.set_visible(!isDefault);
-        labelAcceptButton.set_sensitive(!isDefault);
-      };
+        const labelRestoreButton = new Gtk.Button({
+          icon_name: 'edit-undo-symbolic',
+          has_frame: false,
+          tooltip_text: this._('Restore Default'),
+          valign: Gtk.Align.CENTER,
+        });
+        labelRestoreButton.add_css_class?.('circular');
 
-      labelRestoreButton.connect('clicked', () => {
-        customMenuLabelRow.set_text(defaultMenuLabel);
-        clearLabelFocus();
-      });
-
-      labelAcceptButton.connect('clicked', () => {
-        clearLabelFocus();
-      });
-
-      customMenuLabelRow.connect('notify::text', updateLabelRestoreButtonState);
-      updateLabelRestoreButtonState();
-
-      const labelKeyController = new Gtk.EventControllerKey();
-      labelKeyController.connect('key-pressed', (controller, keyval) => {
-        if (keyval === Gdk.KEY_Escape) {
-          clearLabelFocus();
-          return true;
-        }
-        return false;
-      });
-      customMenuLabelRow.add_controller?.(labelKeyController);
-
-      const labelFocusController = new Gtk.EventControllerFocus();
-      labelFocusController.connect('enter', () => {
-        labelAcceptButton.set_visible(true);
-      });
-      labelFocusController.connect('leave', () => {
+        const labelAcceptButton = new Gtk.Button({
+          icon_name: 'emblem-ok-symbolic',
+          has_frame: false,
+          tooltip_text: this._('Apply Changes'),
+          valign: Gtk.Align.CENTER,
+        });
+        labelAcceptButton.add_css_class?.('circular');
         labelAcceptButton.set_visible(false);
-      });
-      customMenuLabelRow.add_controller?.(labelFocusController);
+        labelAcceptButton.set_sensitive(false);
 
-      customMenuExpanderRow.add_row(customMenuLabelRow);
+        customMenuLabelRow.add_suffix?.(labelAcceptButton);
+        customMenuLabelRow.add_suffix?.(labelRestoreButton);
 
-      // Custom menu command entry
-      const defaultMenuCommand = '';
-      const customMenuCommandRow = new Adw.EntryRow({
-        title: this._('Command'),
-      });
-      customMenuCommandRow.set_placeholder_text?.('gnome-terminal');
-      customMenuCommandRow.set_text(this._settings.get_string('custom-menu-command'));
+        const clearLabelFocus = () => {
+          const root = customMenuLabelRow.get_root?.();
+          if (root && typeof root.set_focus === 'function') {
+            root.set_focus(null);
+          }
+        };
 
-      const commandRestoreButton = new Gtk.Button({
-        icon_name: 'edit-undo-symbolic',
-        has_frame: false,
-        tooltip_text: this._('Restore Default'),
-        valign: Gtk.Align.CENTER,
-      });
-      commandRestoreButton.add_css_class?.('circular');
+        const updateLabelRestoreButtonState = () => {
+          const currentText = customMenuLabelRow.get_text
+            ? customMenuLabelRow.get_text()
+            : customMenuLabelRow.text ?? '';
+          const isDefault = currentText.trim() === defaultMenuLabel;
+          labelRestoreButton.set_sensitive(!isDefault);
+          labelRestoreButton.set_visible(!isDefault);
+          labelAcceptButton.set_sensitive(!isDefault);
+        };
 
-      const commandAcceptButton = new Gtk.Button({
-        icon_name: 'emblem-ok-symbolic',
-        has_frame: false,
-        tooltip_text: this._('Apply Changes'),
-        valign: Gtk.Align.CENTER,
-      });
-      commandAcceptButton.add_css_class?.('circular');
-      commandAcceptButton.set_visible(false);
-      commandAcceptButton.set_sensitive(false);
+        labelRestoreButton.connect('clicked', () => {
+          customMenuLabelRow.set_text(defaultMenuLabel);
+          clearLabelFocus();
+        });
 
-      customMenuCommandRow.add_suffix?.(commandAcceptButton);
-      customMenuCommandRow.add_suffix?.(commandRestoreButton);
+        labelAcceptButton.connect('clicked', () => {
+          clearLabelFocus();
+        });
 
-      const clearCommandFocus = () => {
-        const root = customMenuCommandRow.get_root?.();
-        if (root && typeof root.set_focus === 'function') {
-          root.set_focus(null);
-        }
-      };
+        customMenuLabelRow.connect('notify::text', updateLabelRestoreButtonState);
+        updateLabelRestoreButtonState();
 
-      const updateCommandRestoreButtonState = () => {
-        const currentText = customMenuCommandRow.get_text
-          ? customMenuCommandRow.get_text()
-          : customMenuCommandRow.text ?? '';
-        const isDefault = currentText.trim() === defaultMenuCommand;
-        commandRestoreButton.set_sensitive(!isDefault);
-        commandRestoreButton.set_visible(!isDefault);
-        commandAcceptButton.set_sensitive(!isDefault);
-      };
+        const labelKeyController = new Gtk.EventControllerKey();
+        labelKeyController.connect('key-pressed', (controller, keyval) => {
+          if (keyval === Gdk.KEY_Escape) {
+            clearLabelFocus();
+            return true;
+          }
+          return false;
+        });
+        customMenuLabelRow.add_controller?.(labelKeyController);
 
-      commandRestoreButton.connect('clicked', () => {
-        customMenuCommandRow.set_text(defaultMenuCommand);
-        clearCommandFocus();
-      });
+        const labelFocusController = new Gtk.EventControllerFocus();
+        labelFocusController.connect('enter', () => {
+          labelAcceptButton.set_visible(true);
+        });
+        labelFocusController.connect('leave', () => {
+          labelAcceptButton.set_visible(false);
+        });
+        customMenuLabelRow.add_controller?.(labelFocusController);
 
-      commandAcceptButton.connect('clicked', () => {
-        clearCommandFocus();
-      });
+        customMenuExpanderRow.add_row(customMenuLabelRow);
 
-      customMenuCommandRow.connect('notify::text', updateCommandRestoreButtonState);
-      updateCommandRestoreButtonState();
+        // Custom menu command entry
+        const defaultMenuCommand = '';
+        const customMenuCommandRow = new Adw.EntryRow({
+          title: this._('Command'),
+        });
+        customMenuCommandRow.set_placeholder_text?.('gnome-terminal');
+        customMenuCommandRow.set_text(this._settings.get_string(commandKey));
 
-      const commandKeyController = new Gtk.EventControllerKey();
-      commandKeyController.connect('key-pressed', (controller, keyval) => {
-        if (keyval === Gdk.KEY_Escape) {
-          clearCommandFocus();
-          return true;
-        }
-        return false;
-      });
-      customMenuCommandRow.add_controller?.(commandKeyController);
+        const commandRestoreButton = new Gtk.Button({
+          icon_name: 'edit-undo-symbolic',
+          has_frame: false,
+          tooltip_text: this._('Restore Default'),
+          valign: Gtk.Align.CENTER,
+        });
+        commandRestoreButton.add_css_class?.('circular');
 
-      const commandFocusController = new Gtk.EventControllerFocus();
-      commandFocusController.connect('enter', () => {
-        commandAcceptButton.set_visible(true);
-      });
-      commandFocusController.connect('leave', () => {
+        const commandAcceptButton = new Gtk.Button({
+          icon_name: 'emblem-ok-symbolic',
+          has_frame: false,
+          tooltip_text: this._('Apply Changes'),
+          valign: Gtk.Align.CENTER,
+        });
+        commandAcceptButton.add_css_class?.('circular');
         commandAcceptButton.set_visible(false);
+        commandAcceptButton.set_sensitive(false);
+
+        customMenuCommandRow.add_suffix?.(commandAcceptButton);
+        customMenuCommandRow.add_suffix?.(commandRestoreButton);
+
+        const clearCommandFocus = () => {
+          const root = customMenuCommandRow.get_root?.();
+          if (root && typeof root.set_focus === 'function') {
+            root.set_focus(null);
+          }
+        };
+
+        const updateCommandRestoreButtonState = () => {
+          const currentText = customMenuCommandRow.get_text
+            ? customMenuCommandRow.get_text()
+            : customMenuCommandRow.text ?? '';
+          const isDefault = currentText.trim() === defaultMenuCommand;
+          commandRestoreButton.set_sensitive(!isDefault);
+          commandRestoreButton.set_visible(!isDefault);
+          commandAcceptButton.set_sensitive(!isDefault);
+        };
+
+        commandRestoreButton.connect('clicked', () => {
+          customMenuCommandRow.set_text(defaultMenuCommand);
+          clearCommandFocus();
+        });
+
+        commandAcceptButton.connect('clicked', () => {
+          clearCommandFocus();
+        });
+
+        customMenuCommandRow.connect('notify::text', updateCommandRestoreButtonState);
+        updateCommandRestoreButtonState();
+
+        const commandKeyController = new Gtk.EventControllerKey();
+        commandKeyController.connect('key-pressed', (controller, keyval) => {
+          if (keyval === Gdk.KEY_Escape) {
+            clearCommandFocus();
+            return true;
+          }
+          return false;
+        });
+        customMenuCommandRow.add_controller?.(commandKeyController);
+
+        const commandFocusController = new Gtk.EventControllerFocus();
+        commandFocusController.connect('enter', () => {
+          commandAcceptButton.set_visible(true);
+        });
+        commandFocusController.connect('leave', () => {
+          commandAcceptButton.set_visible(false);
+        });
+        customMenuCommandRow.add_controller?.(commandFocusController);
+
+        customMenuExpanderRow.add_row(customMenuCommandRow);
+
+        menuGroup.add(customMenuExpanderRow);
+        customMenuExpanders.push(customMenuExpanderRow);
+
+        // Handle custom menu enable/disable
+        customMenuExpanderRow.connect('notify::enable-expansion', (widget) => {
+          const isEnabled = widget.get_enable_expansion();
+          this._settings.set_boolean(enabledKey, isEnabled);
+        });
+
+        // Bind custom menu settings
+        this._settings.bind(
+          labelKey,
+          customMenuLabelRow,
+          'text',
+          Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+          commandKey,
+          customMenuCommandRow,
+          'text',
+          Gio.SettingsBindFlags.DEFAULT
+        );
+      }
+
+      // Function to update visibility of custom menu expanders
+      const updateCustomMenuVisibility = () => {
+        const count = this._settings.get_int('custom-menu-count');
+        customMenuExpanders.forEach((expander, index) => {
+          expander.set_visible(index < count);
+        });
+      };
+
+      // Initial visibility update
+      updateCustomMenuVisibility();
+
+      // Update visibility when count changes
+      customMenuCountRow.connect('notify::selected', (widget) => {
+        this._settings.set_int('custom-menu-count', widget.selected);
+        updateCustomMenuVisibility();
       });
-      customMenuCommandRow.add_controller?.(commandFocusController);
-
-      customMenuExpanderRow.add_row(customMenuCommandRow);
-
-      menuGroup.add(customMenuExpanderRow);
-
-      // Handle custom menu enable/disable
-      customMenuExpanderRow.connect('notify::enable-expansion', (widget) => {
-        const isEnabled = widget.get_enable_expansion();
-        this._settings.set_boolean('custom-menu-enabled', isEnabled);
-      });
-
-      // Bind custom menu settings
-      this._settings.bind(
-        'custom-menu-label',
-        customMenuLabelRow,
-        'text',
-        Gio.SettingsBindFlags.DEFAULT
-      );
-
-      this._settings.bind(
-        'custom-menu-command',
-        customMenuCommandRow,
-        'text',
-        Gio.SettingsBindFlags.DEFAULT
-      );
 
       const behaviorGroup = new Adw.PreferencesGroup({
         title: this._('Panel'),

--- a/schemas/org.gnome.shell.extensions.kiwimenu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwimenu.gschema.xml
@@ -31,20 +31,160 @@
       <summary>App Store command</summary>
       <description>Command executed when launching the App Store menu item</description>
     </key>
-    <key type="b" name="custom-menu-enabled">
+    <key type="i" name="custom-menu-count">
+      <default>0</default>
+      <summary>Number of custom menu items</summary>
+      <description>How many custom menu items to display (0-10)</description>
+    </key>
+    <key type="b" name="custom-menu-1-enabled">
       <default>false</default>
-      <summary>Enable custom menu item</summary>
-      <description>Enable or disable the custom menu item</description>
+      <summary>Enable custom menu item 1</summary>
+      <description>Enable or disable custom menu item 1</description>
     </key>
-    <key type="s" name="custom-menu-label">
+    <key type="s" name="custom-menu-1-label">
       <default>''</default>
-      <summary>Custom menu item label</summary>
-      <description>The label text to display for the custom menu item</description>
+      <summary>Custom menu item 1 label</summary>
+      <description>The label text to display for custom menu item 1</description>
     </key>
-    <key type="s" name="custom-menu-command">
+    <key type="s" name="custom-menu-1-command">
       <default>''</default>
-      <summary>Custom menu item command</summary>
-      <description>Command to execute when the custom menu item is activated</description>
+      <summary>Custom menu item 1 command</summary>
+      <description>Command to execute when custom menu item 1 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-2-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 2</summary>
+      <description>Enable or disable custom menu item 2</description>
+    </key>
+    <key type="s" name="custom-menu-2-label">
+      <default>''</default>
+      <summary>Custom menu item 2 label</summary>
+      <description>The label text to display for custom menu item 2</description>
+    </key>
+    <key type="s" name="custom-menu-2-command">
+      <default>''</default>
+      <summary>Custom menu item 2 command</summary>
+      <description>Command to execute when custom menu item 2 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-3-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 3</summary>
+      <description>Enable or disable custom menu item 3</description>
+    </key>
+    <key type="s" name="custom-menu-3-label">
+      <default>''</default>
+      <summary>Custom menu item 3 label</summary>
+      <description>The label text to display for custom menu item 3</description>
+    </key>
+    <key type="s" name="custom-menu-3-command">
+      <default>''</default>
+      <summary>Custom menu item 3 command</summary>
+      <description>Command to execute when custom menu item 3 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-4-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 4</summary>
+      <description>Enable or disable custom menu item 4</description>
+    </key>
+    <key type="s" name="custom-menu-4-label">
+      <default>''</default>
+      <summary>Custom menu item 4 label</summary>
+      <description>The label text to display for custom menu item 4</description>
+    </key>
+    <key type="s" name="custom-menu-4-command">
+      <default>''</default>
+      <summary>Custom menu item 4 command</summary>
+      <description>Command to execute when custom menu item 4 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-5-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 5</summary>
+      <description>Enable or disable custom menu item 5</description>
+    </key>
+    <key type="s" name="custom-menu-5-label">
+      <default>''</default>
+      <summary>Custom menu item 5 label</summary>
+      <description>The label text to display for custom menu item 5</description>
+    </key>
+    <key type="s" name="custom-menu-5-command">
+      <default>''</default>
+      <summary>Custom menu item 5 command</summary>
+      <description>Command to execute when custom menu item 5 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-6-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 6</summary>
+      <description>Enable or disable custom menu item 6</description>
+    </key>
+    <key type="s" name="custom-menu-6-label">
+      <default>''</default>
+      <summary>Custom menu item 6 label</summary>
+      <description>The label text to display for custom menu item 6</description>
+    </key>
+    <key type="s" name="custom-menu-6-command">
+      <default>''</default>
+      <summary>Custom menu item 6 command</summary>
+      <description>Command to execute when custom menu item 6 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-7-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 7</summary>
+      <description>Enable or disable custom menu item 7</description>
+    </key>
+    <key type="s" name="custom-menu-7-label">
+      <default>''</default>
+      <summary>Custom menu item 7 label</summary>
+      <description>The label text to display for custom menu item 7</description>
+    </key>
+    <key type="s" name="custom-menu-7-command">
+      <default>''</default>
+      <summary>Custom menu item 7 command</summary>
+      <description>Command to execute when custom menu item 7 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-8-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 8</summary>
+      <description>Enable or disable custom menu item 8</description>
+    </key>
+    <key type="s" name="custom-menu-8-label">
+      <default>''</default>
+      <summary>Custom menu item 8 label</summary>
+      <description>The label text to display for custom menu item 8</description>
+    </key>
+    <key type="s" name="custom-menu-8-command">
+      <default>''</default>
+      <summary>Custom menu item 8 command</summary>
+      <description>Command to execute when custom menu item 8 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-9-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 9</summary>
+      <description>Enable or disable custom menu item 9</description>
+    </key>
+    <key type="s" name="custom-menu-9-label">
+      <default>''</default>
+      <summary>Custom menu item 9 label</summary>
+      <description>The label text to display for custom menu item 9</description>
+    </key>
+    <key type="s" name="custom-menu-9-command">
+      <default>''</default>
+      <summary>Custom menu item 9 command</summary>
+      <description>Command to execute when custom menu item 9 is activated</description>
+    </key>
+    <key type="b" name="custom-menu-10-enabled">
+      <default>false</default>
+      <summary>Enable custom menu item 10</summary>
+      <description>Enable or disable custom menu item 10</description>
+    </key>
+    <key type="s" name="custom-menu-10-label">
+      <default>''</default>
+      <summary>Custom menu item 10 label</summary>
+      <description>The label text to display for custom menu item 10</description>
+    </key>
+    <key type="s" name="custom-menu-10-command">
+      <default>''</default>
+      <summary>Custom menu item 10 command</summary>
+      <description>Command to execute when custom menu item 10 is activated</description>
     </key>
     <key type="i" name="prefs-default-width">
       <default>700</default>

--- a/src/customMenuItem.js
+++ b/src/customMenuItem.js
@@ -9,23 +9,28 @@ import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
 /**
  * Creates a custom menu item if enabled in settings.
- * 
+ *
  * @param {Gio.Settings} settings - The extension settings object
  * @param {Function} gettextFunc - Translation function
+ * @param {number} index - The custom menu item index (1-10)
  * @returns {PopupMenu.PopupMenuItem|null} The custom menu item or null if disabled
  */
-export function createCustomMenuItem(settings, gettextFunc) {
+export function createCustomMenuItem(settings, gettextFunc, index = 1) {
     if (!settings) {
         return null;
     }
 
-    const enabled = settings.get_boolean('custom-menu-enabled');
+    const enabledKey = `custom-menu-${index}-enabled`;
+    const labelKey = `custom-menu-${index}-label`;
+    const commandKey = `custom-menu-${index}-command`;
+
+    const enabled = settings.get_boolean(enabledKey);
     if (!enabled) {
         return null;
     }
 
-    const label = settings.get_string('custom-menu-label');
-    const command = settings.get_string('custom-menu-command');
+    const label = settings.get_string(labelKey);
+    const command = settings.get_string(commandKey);
 
     // Don't create menu item if label or command is empty
     const trimmedLabel = label?.trim?.() ?? '';

--- a/src/kiwimenu.js
+++ b/src/kiwimenu.js
@@ -78,21 +78,31 @@ export const KiwiMenu = GObject.registerClass(
           this._renderPopupMenu()
         )
       );
+      // Listen for changes to custom menu count
       this._settingsSignalIds.push(
-        this._settings.connect('changed::custom-menu-enabled', () =>
+        this._settings.connect('changed::custom-menu-count', () =>
           this._renderPopupMenu()
         )
       );
-      this._settingsSignalIds.push(
-        this._settings.connect('changed::custom-menu-label', () =>
-          this._renderPopupMenu()
-        )
-      );
-      this._settingsSignalIds.push(
-        this._settings.connect('changed::custom-menu-command', () =>
-          this._renderPopupMenu()
-        )
-      );
+
+      // Listen for changes to all 10 custom menu items
+      for (let i = 1; i <= 10; i++) {
+        this._settingsSignalIds.push(
+          this._settings.connect(`changed::custom-menu-${i}-enabled`, () =>
+            this._renderPopupMenu()
+          )
+        );
+        this._settingsSignalIds.push(
+          this._settings.connect(`changed::custom-menu-${i}-label`, () =>
+            this._renderPopupMenu()
+          )
+        );
+        this._settingsSignalIds.push(
+          this._settings.connect(`changed::custom-menu-${i}-command`, () =>
+            this._renderPopupMenu()
+          )
+        );
+      }
 
       this._menuOpenSignalId = this.menu.connect(
         'open-state-changed',
@@ -193,11 +203,14 @@ export const KiwiMenu = GObject.registerClass(
           case 'menu':
             this._makeMenu(item.title, item.cmds);
             
-            // Add custom menu item right after App Store entry
+            // Add custom menu items right after App Store entry (up to custom-menu-count)
             if (!customMenuAdded && item.commandSettingKey === 'app-store-command') {
-              const customItem = createCustomMenuItem(this._settings, this._gettext.bind(this));
-              if (customItem) {
-                this.menu.addMenuItem(customItem);
+              const customMenuCount = this._settings.get_int('custom-menu-count');
+              for (let i = 1; i <= customMenuCount; i++) {
+                const customItem = createCustomMenuItem(this._settings, this._gettext.bind(this), i);
+                if (customItem) {
+                  this.menu.addMenuItem(customItem);
+                }
               }
               customMenuAdded = true;
             }


### PR DESCRIPTION
- Add custom-menu-count setting to select how many items to display
- Replace single custom-menu-* settings with indexed custom-menu-X-*
- Add ComboRow selector in preferences to choose count (0-10)
- Custom menu item expanders show/hide based on selected count
- Update customMenuItem.js to accept index parameter
- Update kiwimenu.js to render only up to custom-menu-count items

Users can now add up to 10 custom menu entries, choosing exactly how many slots they need rather than a fixed number.