### PR TITLE
feat: Add menu item visibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Kiwi Menu replaces the Activities button with a compact, macOS-inspired launcher
 - **Adaptive logout label**: Personalizes the log out entry with your full name when available.
 - **Curated session controls**: Sleep, restart, shut down, lock, and log out entries mirror the macOS Apple menu workflow.
 - **Hide Activities**: Hide activities button in top panel.
-- **Hide Power buttons**: Hide Lock screen and Power buttons in Quick Settings
+- **Hide Quick Settings buttons**: Hide Lock screen, Power, and Settings buttons in GNOME Quick Settings.
+- **Hide Menu Items**: Customize which items appear in the Kiwi Menu (About, Settings, App Store, Recent Items, Force Quit, Sleep, Restart, Shut Down, Lock Screen, Log Out).
 
 - **Multilingual support**: Fully translatable interface
 

--- a/prefs.js
+++ b/prefs.js
@@ -355,8 +355,8 @@ const OptionsPage = GObject.registerClass(
       this.add(behaviorGroup);
 
       const quickSettingsGroup = new Adw.PreferencesGroup({
-        title: this._('Quick Settings'),
-        description: this._('Choose which default quick action buttons stay visible.'),
+        title: this._('GNOME Quick Settings'),
+        description: this._('Choose which GNOME quick action buttons stay visible.'),
       });
 
       const quickActionToggles = [
@@ -398,6 +398,87 @@ const OptionsPage = GObject.registerClass(
       });
 
       this.add(quickSettingsGroup);
+
+      // Menu Items visibility group
+      const menuItemsGroup = new Adw.PreferencesGroup({
+        title: this._('Menu Items'),
+        description: this._('Choose which menu items appear in the Kiwi Menu.'),
+      });
+
+      const menuItemToggles = [
+        {
+          key: 'hide-about',
+          title: this._('Hide About This PC'),
+          subtitle: this._('Remove the About This PC menu item.'),
+        },
+        {
+          key: 'hide-settings',
+          title: this._('Hide System Settings'),
+          subtitle: this._('Remove the System Settings menu item.'),
+        },
+        {
+          key: 'hide-app-store',
+          title: this._('Hide App Store'),
+          subtitle: this._('Remove the App Store menu item.'),
+        },
+        {
+          key: 'hide-recent-items',
+          title: this._('Hide Recent Items'),
+          subtitle: this._('Remove the Recent Items submenu.'),
+        },
+        {
+          key: 'hide-force-quit',
+          title: this._('Hide Force Quit'),
+          subtitle: this._('Remove the Force Quit menu item.'),
+        },
+        {
+          key: 'hide-sleep',
+          title: this._('Hide Sleep'),
+          subtitle: this._('Remove the Sleep menu item.'),
+        },
+        {
+          key: 'hide-restart',
+          title: this._('Hide Restart'),
+          subtitle: this._('Remove the Restart menu item.'),
+        },
+        {
+          key: 'hide-shutdown',
+          title: this._('Hide Shut Down'),
+          subtitle: this._('Remove the Shut Down menu item.'),
+        },
+        {
+          key: 'hide-lock-screen',
+          title: this._('Hide Lock Screen'),
+          subtitle: this._('Remove the Lock Screen menu item.'),
+        },
+        {
+          key: 'hide-logout',
+          title: this._('Hide Log Out'),
+          subtitle: this._('Remove the Log Out menu item.'),
+        },
+      ];
+
+      menuItemToggles.forEach(({ key, title, subtitle }) => {
+        const toggle = new Gtk.Switch({
+          valign: Gtk.Align.CENTER,
+          active: this._settings.get_boolean(key),
+        });
+
+        const row = new Adw.ActionRow({
+          title,
+          subtitle,
+          activatable_widget: toggle,
+        });
+        row.add_suffix(toggle);
+
+        menuItemsGroup.add(row);
+
+        toggle.connect('notify::active', (widget) => {
+          this._settings.set_boolean(key, widget.get_active());
+        });
+      });
+
+      this.add(menuItemsGroup);
 
       iconSelectorRow.connect('notify::selected', (widget) => {
         this._settings.set_int('icon', widget.selected);

--- a/schemas/org.gnome.shell.extensions.kiwimenu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwimenu.gschema.xml
@@ -31,6 +31,56 @@
       <summary>App Store command</summary>
       <description>Command executed when launching the App Store menu item</description>
     </key>
+    <key type="b" name="hide-about">
+      <default>false</default>
+      <summary>Hide About This PC</summary>
+      <description>Hide the About This PC menu item</description>
+    </key>
+    <key type="b" name="hide-settings">
+      <default>false</default>
+      <summary>Hide System Settings</summary>
+      <description>Hide the System Settings menu item</description>
+    </key>
+    <key type="b" name="hide-app-store">
+      <default>false</default>
+      <summary>Hide App Store</summary>
+      <description>Hide the App Store menu item</description>
+    </key>
+    <key type="b" name="hide-recent-items">
+      <default>false</default>
+      <summary>Hide Recent Items</summary>
+      <description>Hide the Recent Items submenu</description>
+    </key>
+    <key type="b" name="hide-force-quit">
+      <default>false</default>
+      <summary>Hide Force Quit</summary>
+      <description>Hide the Force Quit menu item</description>
+    </key>
+    <key type="b" name="hide-sleep">
+      <default>false</default>
+      <summary>Hide Sleep</summary>
+      <description>Hide the Sleep menu item</description>
+    </key>
+    <key type="b" name="hide-restart">
+      <default>false</default>
+      <summary>Hide Restart</summary>
+      <description>Hide the Restart menu item</description>
+    </key>
+    <key type="b" name="hide-shutdown">
+      <default>false</default>
+      <summary>Hide Shut Down</summary>
+      <description>Hide the Shut Down menu item</description>
+    </key>
+    <key type="b" name="hide-lock-screen">
+      <default>false</default>
+      <summary>Hide Lock Screen</summary>
+      <description>Hide the Lock Screen menu item</description>
+    </key>
+    <key type="b" name="hide-logout">
+      <default>false</default>
+      <summary>Hide Log Out</summary>
+      <description>Hide the Log Out menu item</description>
+    </key>
     <key type="b" name="custom-menu-enabled">
       <default>false</default>
       <summary>Enable custom menu item</summary>

--- a/src/kiwimenu.js
+++ b/src/kiwimenu.js
@@ -94,6 +94,27 @@ export const KiwiMenu = GObject.registerClass(
         )
       );
 
+      // Listen for menu item visibility changes
+      const hideSettingKeys = [
+        'hide-about',
+        'hide-settings',
+        'hide-app-store',
+        'hide-recent-items',
+        'hide-force-quit',
+        'hide-sleep',
+        'hide-restart',
+        'hide-shutdown',
+        'hide-lock-screen',
+        'hide-logout',
+      ];
+      hideSettingKeys.forEach((key) => {
+        this._settingsSignalIds.push(
+          this._settings.connect(`changed::${key}`, () =>
+            this._renderPopupMenu()
+          )
+        );
+      });
+
       this._menuOpenSignalId = this.menu.connect(
         'open-state-changed',
         (_, isOpen) => {
@@ -242,6 +263,18 @@ export const KiwiMenu = GObject.registerClass(
 
         if (outputItem.requiresMultipleUsers && !hasMultipleUsers) {
           continue;
+        }
+
+        // Check if item should be hidden based on hideSettingKey
+        if (outputItem.hideSettingKey) {
+          try {
+            const isHidden = this._settings.get_boolean(outputItem.hideSettingKey);
+            if (isHidden) {
+              continue;
+            }
+          } catch (error) {
+            // If setting doesn't exist, show the item
+          }
         }
 
         items.push(outputItem);

--- a/src/menulayout.json
+++ b/src/menulayout.json
@@ -2,7 +2,8 @@
   {
     "type": "menu",
     "title": "About This PC",
-    "cmds": ["gnome-control-center", "about"]
+    "cmds": ["gnome-control-center", "about"],
+    "hideSettingKey": "hide-about"
   },
   {
     "type": "separator"
@@ -10,20 +11,23 @@
   {
     "type": "menu",
     "title": "System Settings...",
-    "cmds": ["gnome-control-center"]
+    "cmds": ["gnome-control-center"],
+    "hideSettingKey": "hide-settings"
   },
   {
     "type": "menu",
     "title": "App Store...",
     "cmds": ["gnome-software"],
-    "commandSettingKey": "app-store-command"
+    "commandSettingKey": "app-store-command",
+    "hideSettingKey": "hide-app-store"
   },
   {
     "type": "separator"
   },
   {
     "type": "recent-items",
-    "title": "Recent Items"
+    "title": "Recent Items",
+    "hideSettingKey": "hide-recent-items"
   },
   {
     "type": "separator"
@@ -31,7 +35,8 @@
   {
     "type": "menu",
     "title": "Force Quit",
-    "cmds": ["xkill"]
+    "cmds": ["xkill"],
+    "hideSettingKey": "hide-force-quit"
   },
   {
     "type": "separator"
@@ -39,17 +44,20 @@
   {
     "type": "menu",
     "title": "Sleep",
-    "cmds": ["systemctl", "suspend"]
+    "cmds": ["systemctl", "suspend"],
+    "hideSettingKey": "hide-sleep"
   },
   {
     "type": "menu",
     "title": "Restart...",
-    "cmds": ["gnome-session-quit", "--reboot"]
+    "cmds": ["gnome-session-quit", "--reboot"],
+    "hideSettingKey": "hide-restart"
   },
   {
     "type": "menu",
     "title": "Shut Down...",
-    "cmds": ["gnome-session-quit", "--power-off"]
+    "cmds": ["gnome-session-quit", "--power-off"],
+    "hideSettingKey": "hide-shutdown"
   },
   {
     "type": "separator"
@@ -57,11 +65,13 @@
   {
     "type": "menu",
     "title": "Lock Screen",
-    "cmds": ["loginctl", "lock-session"]
+    "cmds": ["loginctl", "lock-session"],
+    "hideSettingKey": "hide-lock-screen"
   },
   {
     "type": "menu",
     "title": "Log Out...",
-    "cmds": ["gnome-session-quit", "--logout"]
+    "cmds": ["gnome-session-quit", "--logout"],
+    "hideSettingKey": "hide-logout"
   }
 ]


### PR DESCRIPTION
Add the ability to hide/show individual Kiwi Menu items:
- About This PC
- System Settings
- App Store
- Recent Items
- Force Quit
- Sleep
- Restart
- Shut Down
- Lock Screen
- Log Out

Changes:
- Add 10 hide-* boolean settings to GSettings schema
- Add hideSettingKey to each menu item in menulayout.json
- Update kiwimenu.js to skip hidden items during menu rendering
- Add signal listeners to re-render menu when visibility changes
- Add "Menu Items" section to preferences with visibility toggles
- Rename "Quick Settings" to "GNOME Quick Settings" to avoid ambiguity