### PR TITLE
FIX: Adjust icon positioning in kiwimenu.js

### DIFF
--- a/src/kiwimenu.js
+++ b/src/kiwimenu.js
@@ -78,10 +78,13 @@ export const KiwiMenu = GObject.registerClass(
         }
       }
 
-      this._icon = new St.Icon({
+     this._icon = new St.Icon({
         style_class: 'menu-button',
+        y_align: Clutter.ActorAlign.CENTER,
+        y_expand: true,
       });
       this.add_child(this._icon);
+      this._icon.translation_y = -1.15;
 
       this._settingsSignalIds.push(
         this._settings.connect('changed::icon', () => this._setIcon())


### PR DESCRIPTION
Fixes the issue where the Kiwi Menu icon was situated above GNOME default panel elements
<img width="1366" height="34" alt="image" src="https://github.com/user-attachments/assets/6f9404ef-8325-41e0-8043-99279f1ea473" />
